### PR TITLE
Add support for processAssets

### DIFF
--- a/wrapper-webpack-plugin.js
+++ b/wrapper-webpack-plugin.js
@@ -82,15 +82,21 @@ class WrapperPlugin {
 
 		function processAssets(compilation, assets) {
 			for (const asset in assets) {
-				// @note There doesn't seem to be a way to get the hash from Source
+				/**
+				 * @note There doesn't seem to be a way to get the hash from Source, so
+				 * not using wrapFile function.
+				 */
 				const headerContent = (typeof header === 'function') ? header(fileName) : header;
 				const footerContent = (typeof footer === 'function') ? footer(fileName) : footer;
 
-				compilation.assets[asset] = new ConcatSource(
-					String(headerContent),
-					compilation.assets[asset],
-					String(footerContent)
-				);
+				if (ModuleFilenameHelpers.matchObject(tester, asset))
+				{
+					compilation.assets[asset] = new ConcatSource(
+						String(headerContent),
+						compilation.assets[asset],
+						String(footerContent)
+					);
+				}
 			}
 		}
 	}

--- a/wrapper-webpack-plugin.js
+++ b/wrapper-webpack-plugin.js
@@ -38,10 +38,20 @@ class WrapperPlugin {
 					wrapChunks(compilation, chunks, footer, header);
 				});
 			} else {
-				compilation.hooks.optimizeChunkAssets.tapAsync('WrapperPlugin', (chunks, done) => {
-					wrapChunks(compilation, chunks, footer, header);
-					done();
-				});
+				// Keep support for optimizeChunkAssets on older Webpack versions
+				if (compilation.hooks.processAssets) {
+					compilation.hooks.processAssets.tapAsync({
+						name: 'WrapperPlugin',
+						stage: 'compilation.PROCESS_ASSETS_STAGE_ADDITIONS'
+					}, (chunks) => {
+						processAssets(compilation, chunks);
+					});
+				} else {
+					compilation.hooks.optimizeChunkAssets.tapAsync('WrapperPlugin', (chunks, done) => {
+						wrapChunks(compilation, chunks, footer, header);
+						done();
+					});
+				}
 			}
 		});
 
@@ -69,6 +79,20 @@ class WrapperPlugin {
 				}
 			}
 		} // wrapChunks
+
+		function processAssets(compilation, assets) {
+			for (const asset in assets) {
+				// @note There doesn't seem to be a way to get the hash from Source
+				const headerContent = (typeof header === 'function') ? header(fileName) : header;
+				const footerContent = (typeof footer === 'function') ? footer(fileName) : footer;
+
+				compilation.assets[asset] = new ConcatSource(
+					String(headerContent),
+					compilation.assets[asset],
+					String(footerContent)
+				);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds support for `processAssets` - webpack's successor to `optimizeChunkAssets`.

Currently, if you use `optimizeChunkAssets` in your build, you will be met with a deprecation warning.

I'm not a Webpack expert by any means, so most of the code for this PR is based off of [this](https://github.com/levp/wrapper-webpack-plugin/issues/11#issuecomment-708215938) comment in #11.

Something that someone who has better knowledge of Webpack should comment on: 
- Is it possible to get the asset/chunk hash from `Source`? I don't see a method to get it directly on the documentation, and I'd like to be able to just use the pre-existing `writeFile` function.
- Should compatibility for optimizeChunkAssets be retained? I have it retained for now, but I'm not sure if it's desirable